### PR TITLE
keep mxm context alive as long as pml_yalla component is open.

### DIFF
--- a/ompi/mca/pml/yalla/pml_yalla.h
+++ b/ompi/mca/pml/yalla/pml_yalla.h
@@ -37,6 +37,8 @@ struct mca_pml_yalla_module {
     mca_pml_base_module_t    super;
 
     /* MXM global objects */
+    mxm_context_opts_t       *ctx_opts;
+    mxm_ep_opts_t            *ep_opts;
     mxm_h                    mxm_context;
     mxm_ep_h                 mxm_ep;
 
@@ -79,6 +81,8 @@ extern mca_pml_yalla_module_t ompi_pml_yalla;
                             __FILE__, __LINE__, __FUNCTION__, ## __VA_ARGS__); \
     }
 
+int mca_pml_yalla_open(void);
+int mca_pml_yalla_close(void);
 int mca_pml_yalla_init(void);
 int mca_pml_yalla_cleanup(void);
 

--- a/ompi/mca/pml/yalla/pml_yalla_component.c
+++ b/ompi/mca/pml/yalla/pml_yalla_component.c
@@ -69,11 +69,18 @@ static int mca_pml_yalla_component_open(void)
 {
     ompi_pml_yalla.output = opal_output_open(NULL);
     opal_output_set_verbosity(ompi_pml_yalla.output, ompi_pml_yalla.verbose);
-    return 0;
+    return mca_pml_yalla_open();
 }
 
 static int mca_pml_yalla_component_close(void)
 {
+    int rc;
+
+    rc = mca_pml_yalla_close();
+    if (rc != 0) {
+        return rc;
+    }
+
     opal_output_close(ompi_pml_yalla.output);
     return 0;
 }


### PR DESCRIPTION
pml_yalla_del_comm may be called after yalla module is finalized, which
leads to invalid memory access if mxm context is already destroyed in
this point.