### PR TITLE
HCOLL: Fix assertion

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -101,7 +101,6 @@ static void mca_coll_hcoll_module_destruct(mca_coll_hcoll_module_t *hcoll_module
         hcoll_destroy_context(hcoll_module->hcoll_context,
                               (rte_grp_handle_t)hcoll_module->comm,
                               &context_destroyed);
-        assert(context_destroyed);
     }
     mca_coll_hcoll_module_clear(hcoll_module);
 }


### PR DESCRIPTION
hcoll context may not be destroyed if it is cached.