### PR TITLE
yalla: fix valgrind error due to uninitialized status field.

### DIFF
--- a/ompi/mca/pml/yalla/pml_yalla_request.h
+++ b/ompi/mca/pml/yalla/pml_yalla_request.h
@@ -181,6 +181,7 @@ void mca_pml_yalla_init_reqs(void);
                 (_mpi_status)->MPI_ERROR  = OMPI_SUCCESS; \
                 break; \
             case MXM_ERR_CANCELED: \
+                (_mpi_status)->MPI_ERROR  = OMPI_SUCCESS; \
                 (_mpi_status)->_cancelled = true; \
                 break; \
             case MXM_ERR_MESSAGE_TRUNCATED: \


### PR DESCRIPTION
port v1.10 https://github.com/open-mpi/ompi-release/commit/76053c1786d4bde3df65da430f50ab468b998657

@yosefe @miked-mellanox 